### PR TITLE
Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,66 @@
-#  GSRouting
+# GSRouting
+
 A light-weight Swift Package to improve the way different types of sheets and navigation destinations are presented, as well as
 navigating between tabs.
 
-# Getting started
+> [!WARNING]  
+> **Only suitable for iOS 16 and above**
 
-## Step 1: Using `RoutableTabView`
-RoutableTabView allows for programmatic navigation between tabs in the TabBar.
+## Table of Contents
+
+-   [Installation](#installation)
+-   [Usage](#usage)
+-   [License](#license)
+
+## Installation <a name="installation"></a>
+
+### Xcode
+
+To integrate GSRouting into your Xcode project using Swift Package Manager, follow these steps:
+
+1. Open your Xcode project.
+2. Navigate to "File" -> "Swift Packages" -> "Add Package Dependency..."
+3. Paste the package URL `https://github.com/ryan-creator/GSRouting.git` and click "Next."
+4. Choose the version rule according to your preference and click "Next."
+5. Click "Finish."
+
+Now you can import the package in your Swift files.
+
+### Swift Package Manager (SPM)
+
+If you want to use GSRouting in any other project that uses SPM, add the package as a dependency in Package.swift:
+
+```swift
+dependencies: [
+    .package(
+        name: "GSRouting",
+        url: "https://github.com/ryan-creator/GSRouting.git",
+        from: "1.0.0"
+    ),
+]
 ```
+
+Next, add GSRouting as a dependency of your test target:
+
+````swift
+targets: [
+  .target(
+    name: "MyApp",
+    dependencies: ["GSRouting", ...]
+  ),
+  .testTarget(...)
+]
+
+## Usage <a name="usage"></a>
+
+### Step 1: Using `RoutableTabView`
+
+RoutableTabView allows for programmatic navigation between tabs in the TabBar.
+
+```swift
 @main
 struct AppView: App {
-    
+
     var body: some Scene {
         WindowGroup {
             // Use `RoutableTabView` at the root of the app in the `@main` view.
@@ -20,93 +71,163 @@ struct AppView: App {
             ])
         }
     }
+
 }
-```
+````
+
+## Usage <a name="usage"></a>
 
 ### Creating a `TabRoute`:
+
 A TabRoute conforming object represents a single tab, providing functions to render the label displayed in the tab bar,
-as well as the content displayed when the tab is selected. 
+as well as the content displayed when the tab is selected.
 
 **Note:** The `makeLabel` and `makeContent` functions are called when the state of the tab
 changes, so it is possible to do things like changing the tab icon when selected/deselected etc.
 
-**Important:** It's recommended to use the `.routable()` modifier in the `makeContent` function for each tab, which allows
-navigation to work within it's subviews.
-
-```
+```swift
 struct HomeTabRoute: TabRoute {
-    let id: String = "home"
-    
+let id: String = "home"
+
     func makeLabel(context: Context) -> some View {
         Label("Home", systemImage: context.isSelected ? "house.fill" : "house")
     }
-    
+
     func makeContent(context: Context) -> some View {
-        HomeContainerView().routable()
+        HomeView()
     }
+
 }
 ```
 
-## Step 2: Navigating to & presenting views.
+### Step 2: Navigating to & presenting views.
+
 All navigation operations can be performed by interacting with the injected instance of `AppNavigationRouter`. This can be done by a property marked with `@Router` in a SwiftUI view.
 
 **Important:** It's important the parent view applies the `.routable()` modifier which injects the router and enables navigation functionality.
 
 ### Usage of `@Router`:
 
-```
-struct MyViewSomewhereInTheApp: View {
-    @Router private var router
+```swift
+struct ContentView: View {
 
-    var body: some View {
-      VStack {
-        Button("Go to next page") {
-         router.push(.anotherPage)
-        }
+  @Router private var router
 
-        Button("Present a sheet") {
-         router.push(.someSheet)
-        }
+  var body: some View {
+    VStack {
+      Button("Go to next page") {
+        router.push(PageView())
+      }
 
-        Button("Go back 1 page") {
-         router.pop()
-        }
-
-        Button("Go back to start") {
-         router.popToRoot()
-        }
-
-        Button("Present full screen cover") {
-         router.presentCover(.someCover)
-        }
-
-        Button("Go to settings tab") {
-         router.switchTab(id: "settings")
-        }
+      Button("Present a sheet") {
+        router.presentSheet(SheetView())
       }
     }
+  }
 }
 ```
 
 ### Creating a `ViewRoute` for presentation/navigation:
-A ViewRoute declaration allows for presenting and navigating to the view returned in it's `makeBody` function.
+
+A ViewRoute declaration allows for presenting and navigating to the view returned in it's `body` var.
+
 ViewRoutes are passed into functions on the router like `push(_:), presentSheet(_:)`, etc.
-```
+
+```swift
 struct MyViewRoute: ViewRoute {
-    func makeBody(context: Context) -> some View {
-      MyView()
-    }
+  var body: some View {
+    MyView()
+  }
 }
 ```
 
 For convenience, an extension on `ViewRoute` can be made to declare the route as a property, so XCode will suggest our custom `ViewRoute` in the auto-complete window that appears when typing.
-```
+
+```swift
 extension ViewRoute where Self == MyViewRoute {
-   var myView: Self { .init() }
+  var myView: Self { .init() }
 }
 ```
 
 That allows for this syntax to work:
-```
+
+```swift
 router.push(.myView)
 ```
+
+## Advanced Usage
+
+### Queueing & Priority
+
+GSRouting supports queueing for sheets and full-screen covers, allowing multiple presentation requests to be handled sequentially based on their assigned priority. This ensures that the highest-priority views are displayed first.
+
+#### Setting Priority
+
+Each route has an associated RoutePriority value, which can be set when calling navigation functions such as push, presentSheet, or presentCover. By default, the priority is .normal.
+
+Example of assigning a priority:
+
+```swift
+router.presentSheet(MySheetViewRoute(), priority: .high)
+```
+
+#### How the Queue Works
+
+When a navigation request is made for a sheet or cover: 1. It is added to a queue managed by QueueManager. 2. The queue automatically processes the highest-priority request first. 3. Subsequent requests are handled only after the currently presented view is dismissed.
+
+This mechanism ensures that multiple requests don’t cause overlapping presentations.
+
+### Access Navigation Path
+
+GSRouting provides access to the navigation path, enabling developers to track or modify the sequence of navigations.
+
+#### Tracking the Path
+
+The AppNavigationRouter updates a path of navigation steps (NavigationStep) whenever a navigation action occurs. This path is available via the environment:
+
+```swift
+@Environment(\.navigationPath) private var navigationPath
+```
+
+Example of using the navigation path:
+
+```swift
+struct MyView: View {
+
+  @Environment(\.navigationPath) private var navigationPath
+
+  @State private var sheetId = "unknown"
+
+  var body: some View {
+    Text("This is \(sheetId)")
+      .onAppear {
+        if case .sheet(let id) = navigationPath {
+          sheetId = id
+        }
+      }
+  }
+}
+```
+
+### Logging Navigation Path
+
+For debugging purposes, GSRouting can log the navigation path to the console whenever it changes. This feature is activated by passing the --log-navigation runtime argument when launching the app. The log provides insights into navigation behavior, which can be useful for tracking unexpected navigations or ensuring navigation steps are executed as expected.
+
+#### Adding Runtime Arguments in Xcode Scheme
+
+To enable logging in Xcode during development: 1. Open your project in Xcode. 2. In the toolbar, click the Scheme Selector (next to the Stop button) and choose Edit Scheme. 3. In the Edit Scheme dialog, select the Run action from the sidebar. 4. Navigate to the Arguments tab at the top of the dialog. 5. Under the Arguments Passed On Launch section, click the + button. 6. Add the argument --log-navigation and ensure the checkbox next to it is selected. 7. Click Close to save your changes.
+
+Now, every time the app runs using this scheme, navigation path changes will be logged to the console.
+
+With logging enabled, the console will display updates like the following when navigation steps are added or removed:
+
+```
+[Navigation Path Update] Current path: [NavigationStep.push(id: "home"), NavigationStep.sheet(id: "details")]
+[Navigation Path Update] Current path: [NavigationStep.push(id: "home")]
+```
+
+This log output helps you verify the flow of navigation actions, ensuring they align with your expectations during development and debugging.
+
+## License <a name="license"></a>
+
+This library is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,15 @@ For debugging purposes, GSRouting can log the navigation path to the console whe
 
 #### Adding Runtime Arguments in Xcode Scheme
 
-To enable logging in Xcode during development: 1. Open your project in Xcode. 2. In the toolbar, click the Scheme Selector (next to the Stop button) and choose Edit Scheme. 3. In the Edit Scheme dialog, select the Run action from the sidebar. 4. Navigate to the Arguments tab at the top of the dialog. 5. Under the Arguments Passed On Launch section, click the + button. 6. Add the argument --log-navigation and ensure the checkbox next to it is selected. 7. Click Close to save your changes.
+To enable logging in Xcode during development:
+
+1. Open your project in Xcode.
+2. In the toolbar, click the Scheme Selector (next to the Stop button) and choose Edit Scheme.
+3. In the Edit Scheme dialog, select the Run action from the sidebar.
+4. Navigate to the Arguments tab at the top of the dialog.
+5. Under the Arguments Passed On Launch section, click the + button.
+6. Add the argument --log-navigation and ensure the checkbox next to it is selected.
+7. Click Close to save your changes.
 
 Now, every time the app runs using this scheme, navigation path changes will be logged to the console.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies: [
 
 Next, add GSRouting as a dependency of your test target:
 
-````swift
+```swift
 targets: [
   .target(
     name: "MyApp",
@@ -53,6 +53,7 @@ targets: [
   ),
   .testTarget(...)
 ]
+```
 
 ## Usage <a name="usage"></a>
 
@@ -76,11 +77,9 @@ struct AppView: App {
     }
 
 }
-````
+```
 
-## Usage <a name="usage"></a>
-
-### Creating a `TabRoute`:
+#### Creating a `TabRoute`:
 
 A TabRoute conforming object represents a single tab, providing functions to render the label displayed in the tab bar,
 as well as the content displayed when the tab is selected.
@@ -109,7 +108,7 @@ All navigation operations can be performed by interacting with the injected inst
 
 **Important:** It's important the parent view applies the `.routable()` modifier which injects the router and enables navigation functionality.
 
-### Usage of `@Router`:
+#### Usage of `@Router`:
 
 ```swift
 struct ContentView: View {
@@ -130,7 +129,7 @@ struct ContentView: View {
 }
 ```
 
-### Creating a `ViewRoute` for Presentation & Navigation:
+#### Creating a `ViewRoute` for Presentation & Navigation:
 
 A ViewRoute declaration allows for presenting and navigating to the view returned in it's `body` var.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ navigating between tabs.
 
 -   [Installation](#installation)
 -   [Usage](#usage)
+-   [Queue & Priority](#queue)
+-   [Access Navigation Path](#navigation-path)
+-   [Logging & Debugging](#logging)
 -   [License](#license)
 
 ## Installation <a name="installation"></a>
@@ -100,7 +103,7 @@ let id: String = "home"
 }
 ```
 
-### Step 2: Navigating to & presenting views.
+### Step 2: Navigating to & Presenting Views.
 
 All navigation operations can be performed by interacting with the injected instance of `AppNavigationRouter`. This can be done by a property marked with `@Router` in a SwiftUI view.
 
@@ -127,7 +130,7 @@ struct ContentView: View {
 }
 ```
 
-### Creating a `ViewRoute` for presentation/navigation:
+### Creating a `ViewRoute` for Presentation & Navigation:
 
 A ViewRoute declaration allows for presenting and navigating to the view returned in it's `body` var.
 
@@ -157,7 +160,7 @@ router.push(.myView)
 
 ## Advanced Usage
 
-### Queueing & Priority
+### Queueing & Priority <a name="queue"></a>
 
 GSRouting supports queueing for sheets and full-screen covers, allowing multiple presentation requests to be handled sequentially based on their assigned priority. This ensures that the highest-priority views are displayed first.
 
@@ -177,7 +180,7 @@ When a navigation request is made for a sheet or cover: 1. It is added to a queu
 
 This mechanism ensures that multiple requests don’t cause overlapping presentations.
 
-### Access Navigation Path
+### Access Navigation Path <a name="navigation-path"></a>
 
 GSRouting provides access to the navigation path, enabling developers to track or modify the sequence of navigations.
 
@@ -209,7 +212,7 @@ struct MyView: View {
 }
 ```
 
-### Logging Navigation Path
+### Logging Navigation Path <a name="logging"></a>
 
 For debugging purposes, GSRouting can log the navigation path to the console whenever it changes. This feature is activated by passing the --log-navigation runtime argument when launching the app. The log provides insights into navigation behavior, which can be useful for tracking unexpected navigations or ensuring navigation steps are executed as expected.
 

--- a/Sources/GSRouting/AppNavigationRouter+Public.swift
+++ b/Sources/GSRouting/AppNavigationRouter+Public.swift
@@ -32,9 +32,8 @@ public extension AppNavigationRouter {
     ///
     /// - Parameters:
     ///   - view: The view to push onto the navigation stack. Must conform to `ViewRoute`.
-    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
-    func push(_ view: some ViewRoute, priority: ActionPriority = .normal) {
-        callbacks?.push(AnyViewRoute(erasing: view, priority: priority))
+    func push(_ view: some ViewRoute) {
+        callbacks?.push(AnyViewRoute(erasing: view))
     }
 
     /// Presents a new view as a modal sheet.
@@ -43,7 +42,7 @@ public extension AppNavigationRouter {
     ///   - view: The view to present as a sheet. Must conform to `ViewRoute`.
     ///   - priority: The priority of the navigation action. Defaults to `.normal`.
     func presentSheet(_ view: some ViewRoute, priority: ActionPriority = .normal) {
-        callbacks?.presentSheet(AnyViewRoute(erasing: view, priority: priority))
+        callbacks?.presentSheet(AnyViewRoute(erasing: view, priority: priority, type: .sheet))
     }
 
     /// Presents a new view as a full-screen cover.
@@ -52,17 +51,16 @@ public extension AppNavigationRouter {
     ///   - view: The view to present as a full-screen cover. Must conform to `ViewRoute`.
     ///   - priority: The priority of the navigation action. Defaults to `.normal`.
     func presentCover(_ view: some ViewRoute, priority: ActionPriority = .normal) {
-        callbacks?.presentCover(AnyViewRoute(erasing: view, priority: priority))
+        callbacks?.presentCover(AnyViewRoute(erasing: view, priority: priority, type: .fullScreenCover))
     }
 
     /// Replaces the current navigation path with a new sequence of views.
     ///
     /// - Parameters:
     ///   - path: An array of views to set as the new navigation path. Each view must conform to `ViewRoute`.
-    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
-    func presentPath(_ path: [some ViewRoute], priority: ActionPriority = .normal) {
+    func presentPath(_ path: [some ViewRoute]) {
         callbacks?.presentPath(path.map({ route in
-            AnyViewRoute(erasing: route, priority: priority)
+            AnyViewRoute(erasing: route)
         }))
     }
 

--- a/Sources/GSRouting/AppNavigationRouter+Public.swift
+++ b/Sources/GSRouting/AppNavigationRouter+Public.swift
@@ -1,0 +1,82 @@
+//
+//  AppNavigationRouter+Public.swift
+//  GSRouting
+//
+//  Created by Ryan Cole on 4/12/2024.
+//
+
+public extension AppNavigationRouter {
+
+    /// Pops the current view off the navigation stack.
+    ///
+    /// This function removes the topmost view in the navigation hierarchy, navigating back to the previous view.
+    func pop() {
+        callbacks?.pop()
+    }
+
+    /// Pops all views off the navigation stack and returns to the root view.
+    ///
+    /// This function clears the navigation stack and navigates directly back to the root of the stack.
+    func popToRoot() {
+        callbacks?.popToRoot()
+    }
+
+    /// Switches the active tab in a tab-based navigation structure.
+    ///
+    /// - Parameter id: The identifier of the tab to switch to.
+    func switchTab(id: String) {
+        callbacks?.switchToTab(id)
+    }
+
+    /// Pushes a new view onto the navigation stack.
+    ///
+    /// - Parameters:
+    ///   - view: The view to push onto the navigation stack. Must conform to `ViewRoute`.
+    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
+    func push(_ view: some ViewRoute, priority: ActionPriority = .normal) {
+        callbacks?.push(AnyViewRoute(erasing: view, priority: priority))
+    }
+
+    /// Presents a new view as a modal sheet.
+    ///
+    /// - Parameters:
+    ///   - view: The view to present as a sheet. Must conform to `ViewRoute`.
+    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
+    func presentSheet(_ view: some ViewRoute, priority: ActionPriority = .normal) {
+        callbacks?.presentSheet(AnyViewRoute(erasing: view, priority: priority))
+    }
+
+    /// Presents a new view as a full-screen cover.
+    ///
+    /// - Parameters:
+    ///   - view: The view to present as a full-screen cover. Must conform to `ViewRoute`.
+    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
+    func presentCover(_ view: some ViewRoute, priority: ActionPriority = .normal) {
+        callbacks?.presentCover(AnyViewRoute(erasing: view, priority: priority))
+    }
+
+    /// Replaces the current navigation path with a new sequence of views.
+    ///
+    /// - Parameters:
+    ///   - path: An array of views to set as the new navigation path. Each view must conform to `ViewRoute`.
+    ///   - priority: The priority of the navigation action. Defaults to `.normal`.
+    func presentPath(_ path: [some ViewRoute], priority: ActionPriority = .normal) {
+        callbacks?.presentPath(path.map({ route in
+            AnyViewRoute(erasing: route, priority: priority)
+        }))
+    }
+
+    /// Closes the currently presented modal sheet, if any.
+    ///
+    /// This function dismisses the topmost sheet in the modal presentation stack.
+    func closeSheet() {
+        callbacks?.closeSheet()
+    }
+
+    /// Closes the currently presented full-screen cover, if any.
+    ///
+    /// This function dismisses the topmost full-screen cover in the modal presentation stack.
+    func closeFullScreenCover() {
+        callbacks?.closeFullScreenCover()
+    }
+}

--- a/Sources/GSRouting/AppNavigationRouter.swift
+++ b/Sources/GSRouting/AppNavigationRouter.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 @MainActor
 public final class AppNavigationRouter: ObservableObject {
-    private var callbacks: Callbacks?
+    var callbacks: Callbacks?
     
-    internal func initialize(
+    func initialize(
         push: @escaping (AnyViewRoute) -> Void,
         pop: @escaping () -> Void,
         popToRoot: @escaping () -> Void,
@@ -35,45 +35,7 @@ public final class AppNavigationRouter: ObservableObject {
         )
     }
     
-    public func pop() {
-        callbacks?.pop()
-    }
-    
-    public func popToRoot() {
-        callbacks?.popToRoot()
-    }
-    
-    public func switchTab(id: String) {
-        callbacks?.switchToTab(id)
-    }
-    
-    public func push(_ view: some ViewRoute, priority: RoutePriority = .normal) {
-        callbacks?.push(AnyViewRoute(erasing: view, priority: priority))
-    }
-    
-    public func presentSheet(_ view: some ViewRoute, priority: RoutePriority = .normal) {
-        callbacks?.presentSheet(AnyViewRoute(erasing: view, priority: priority))
-    }
-    
-    public func presentCover(_ view: some ViewRoute, priority: RoutePriority = .normal) {
-        callbacks?.presentCover(AnyViewRoute(erasing: view, priority: priority))
-    }
-    
-    public func presentPath(_ path: [some ViewRoute], priority: RoutePriority = .normal) {
-        callbacks?.presentPath(path.map({ route in
-            AnyViewRoute(erasing: route, priority: priority)
-        }))
-    }
-    
-    public func closeSheet() {
-        callbacks?.closeSheet()
-    }
-    
-    public func closeFullScreenCover() {
-        callbacks?.closeFullScreenCover()
-    }
-    
-    private struct Callbacks {
+    struct Callbacks {
         let push: (_ view: AnyViewRoute) -> Void
         let pop: () -> Void
         let popToRoot: () -> Void

--- a/Sources/GSRouting/AppNavigationRouter.swift
+++ b/Sources/GSRouting/AppNavigationRouter.swift
@@ -5,11 +5,10 @@
 //  Created by Noah Little on 11/6/2024.
 //
 
-import Foundation
+import SwiftUI
 
-/// A class to handle navigation routing operations, such as presenting sheets,
-/// switching tabs, pushing onto the nav stack etc.
-@MainActor public final class AppNavigationRouter: ObservableObject {
+@MainActor
+public final class AppNavigationRouter: ObservableObject {
     private var callbacks: Callbacks?
     
     internal func initialize(
@@ -18,46 +17,60 @@ import Foundation
         popToRoot: @escaping () -> Void,
         presentSheet: @escaping (AnyViewRoute) -> Void,
         presentCover: @escaping (AnyViewRoute) -> Void,
-        switchToTab: @escaping (_ id: String) -> Void
+        switchToTab: @escaping (_ id: String) -> Void,
+        presentPath: @escaping (_ path: [AnyViewRoute]) -> Void,
+        closeSheet: @escaping () -> Void,
+        closeFullScreenCover: @escaping () -> Void
     ) {
-        self.callbacks = .init(
+        self.callbacks = Callbacks(
             push: push,
             pop: pop,
             popToRoot: popToRoot,
             presentSheet: presentSheet,
             presentCover: presentCover,
-            switchToTab: switchToTab
+            switchToTab: switchToTab,
+            presentPath: presentPath,
+            closeSheet: closeSheet,
+            closeFullScreenCover: closeFullScreenCover
         )
     }
-
-    /// Pushes the view for the given route onto the navigation stack.
-    public func push(_ view: some ViewRoute) {
-        callbacks?.push(AnyViewRoute(erasing: view))
-    }
     
-    /// Pops the last view route from the navigation stack.
     public func pop() {
         callbacks?.pop()
     }
     
-    /// Resets the navigation stack, returning to the root view.
     public func popToRoot() {
         callbacks?.popToRoot()
     }
     
-    /// Presents the view for the given route in a sheet.
-    public func presentSheet(_ view: some ViewRoute) {
-        callbacks?.presentSheet(AnyViewRoute(erasing: view))
-    }
-    
-    /// Presents the view for the given route in a fullScreenCover.
-    public func presentCover(_ view: some ViewRoute) {
-        callbacks?.presentCover(AnyViewRoute(erasing: view))
-    }
-    
-    /// Switches to the tab with the given ID.
     public func switchTab(id: String) {
         callbacks?.switchToTab(id)
+    }
+    
+    public func push(_ view: some ViewRoute, priority: RoutePriority = .normal) {
+        callbacks?.push(AnyViewRoute(erasing: view, priority: priority))
+    }
+    
+    public func presentSheet(_ view: some ViewRoute, priority: RoutePriority = .normal) {
+        callbacks?.presentSheet(AnyViewRoute(erasing: view, priority: priority))
+    }
+    
+    public func presentCover(_ view: some ViewRoute, priority: RoutePriority = .normal) {
+        callbacks?.presentCover(AnyViewRoute(erasing: view, priority: priority))
+    }
+    
+    public func presentPath(_ path: [some ViewRoute], priority: RoutePriority = .normal) {
+        callbacks?.presentPath(path.map({ route in
+            AnyViewRoute(erasing: route, priority: priority)
+        }))
+    }
+    
+    public func closeSheet() {
+        callbacks?.closeSheet()
+    }
+    
+    public func closeFullScreenCover() {
+        callbacks?.closeFullScreenCover()
     }
     
     private struct Callbacks {
@@ -67,5 +80,8 @@ import Foundation
         let presentSheet: (_ view: AnyViewRoute) -> Void
         let presentCover: (_ view: AnyViewRoute) -> Void
         let switchToTab: (_ id: String) -> Void
+        let presentPath: (_ path: [AnyViewRoute]) -> Void
+        let closeSheet: () -> Void
+        let closeFullScreenCover: () -> Void
     }
 }

--- a/Sources/GSRouting/AppTabRouter.swift
+++ b/Sources/GSRouting/AppTabRouter.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-@MainActor internal final class AppTabRouter: ObservableObject {
+@MainActor
+internal final class AppTabRouter: ObservableObject {
     
     @Published 
     var selectedTab: AnyTabRoute

--- a/Sources/GSRouting/Protocols/TabRoute.swift
+++ b/Sources/GSRouting/Protocols/TabRoute.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-// MARK: - TabRoute
-
 /**
  A protocol defining the structure of a tab in a tab-based navigation system.
 
@@ -63,8 +61,6 @@ public protocol TabRoute: Hashable, Equatable, Identifiable where ID == String {
     typealias Context = RoutableTabContext
 }
 
-// MARK: - Protocol default implementations
-
 public extension TabRoute {
     
     func hash(into hasher: inout Hasher) {
@@ -75,8 +71,6 @@ public extension TabRoute {
         lhs.id == rhs.id
     }
 }
-
-// MARK: - Context
 
 /**
  Contextual information for a routable tab within a tab-based navigation system.

--- a/Sources/GSRouting/Protocols/ViewRoute.swift
+++ b/Sources/GSRouting/Protocols/ViewRoute.swift
@@ -7,35 +7,6 @@
 
 import SwiftUI
 
-// MARK: - ViewRoute
-
-/**
- A protocol defining a view that can be presented by the `AppNavigationRouter`.
-
- This protocol allows for the creation of presentable views with a specific body.
-
- - Note: Implementing types must conform to `Hashable`, `Equatable`, `Identifiable` where the identifier type `ID` is `String`.
-
- - Important: The associated type `Body` must conform to SwiftUI's `View` protocol.
-
- Usage:
- ```swift
- struct MyViewRoute: ViewRoute {
-
-     func makeBody(context: Context) -> some View {
-        switch context.presentationMode {
-            case .destination:
-                MyView()
-                    .navigationBarTitleDisplayMode(.inline)
-            default:
-                 MyView()
-                    .navigationBarTitleDisplayMode(.large)
-                    .routable()
-        }
-     }
- }
- ```
- */
 @_typeEraser(AnyViewRoute)
 public protocol ViewRoute: Hashable, Equatable, Identifiable where ID == String {
     /// The type of view representing the body of this ViewRoute.
@@ -49,13 +20,8 @@ public protocol ViewRoute: Hashable, Equatable, Identifiable where ID == String 
 
      - Returns: A SwiftUI `View` representing the main content of the view.
      */
-    @MainActor @ViewBuilder
-    func makeBody(context: Context) -> Body
-    
-    typealias Context = RoutableViewContext
+    @ViewBuilder @MainActor @preconcurrency var body: Self.Body { get }
 }
-
-// MARK: - Protocol default implementations
 
 public extension ViewRoute {
     
@@ -69,22 +35,5 @@ public extension ViewRoute {
     
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.id == rhs.id
-    }
-}
-
-// MARK: - Configuration
-
-///  Contextual information for a routable view within a navigation system.
-///
-///  - SeeAlso: ``ViewRoute``
-public struct RoutableViewContext {
-    /// The mode in which the view is presented.
-    public let presentationMode: Self.PresentationMode
-    
-    /// Identification for how the view is being presented.
-    public enum PresentationMode {
-        case destination
-        case sheet
-        case fullScreenCover
     }
 }

--- a/Sources/GSRouting/Protocols/ViewRoute.swift
+++ b/Sources/GSRouting/Protocols/ViewRoute.swift
@@ -7,6 +7,23 @@
 
 import SwiftUI
 
+/**
+ A protocol defining a view that can be presented by the `AppNavigationRouter`.
+ 
+ This protocol allows for the creation of presentable views with a specific body.
+ 
+ - Important: The associated type `Body` must conform to SwiftUI's `View` protocol.
+ 
+ Usage:
+ ```swift
+ struct MyViewRoute: ViewRoute {
+     var body: some View {
+         Text("Hello World!")
+        }
+     }
+ }
+ ```
+ */
 @_typeEraser(AnyViewRoute)
 public protocol ViewRoute: Hashable, Equatable, Identifiable where ID == String {
     /// The type of view representing the body of this ViewRoute.

--- a/Sources/GSRouting/Utilities/AnyRoute.swift
+++ b/Sources/GSRouting/Utilities/AnyRoute.swift
@@ -8,24 +8,30 @@
 import Foundation
 import SwiftUI
 
+public enum RoutePriority: Int {
+    case low, normal, high, critical
+}
+
 /// A type-erased ViewRoute.
 public struct AnyViewRoute: ViewRoute {
-    public typealias Body = AnyView
         
     private let _route: any ViewRoute
+    private let _priority: RoutePriority
     
     public var id: ID { _route.id }
     
-    public init(erasing wrappedValue: any ViewRoute) {
+    public init(erasing wrappedValue: any ViewRoute, priority: RoutePriority) {
         self._route = wrappedValue
+        self._priority = priority
     }
     
     public init(erasing wrappedValue: some ViewRoute) {
         self._route = wrappedValue
+        self._priority = .normal
     }
     
-    public func makeBody(context: Context) -> Self.Body {
-        AnyView(_route.makeBody(context: context))
+    public var body: some View {
+        AnyView(_route.body)
     }
 }
 

--- a/Sources/GSRouting/Utilities/AnyRoute.swift
+++ b/Sources/GSRouting/Utilities/AnyRoute.swift
@@ -12,22 +12,33 @@ public enum ActionPriority: Int {
     case low, normal, high, critical
 }
 
+public enum RouteType {
+    case sheet, fullScreenCover
+}
+
 /// A type-erased ViewRoute.
 public struct AnyViewRoute: ViewRoute {
         
     private let _route: any ViewRoute
-    private let _priority: ActionPriority
     
     public var id: ID { _route.id }
+    public let priority: ActionPriority?
+    public let type: RouteType?
     
-    public init(erasing wrappedValue: any ViewRoute, priority: ActionPriority) {
+    public init(
+        erasing wrappedValue: any ViewRoute,
+        priority: ActionPriority? = nil,
+        type: RouteType? = nil
+    ) {
+        self.type = type
+        self.priority = priority
         self._route = wrappedValue
-        self._priority = priority
     }
     
     public init(erasing wrappedValue: some ViewRoute) {
+        self.type = nil
+        self.priority = nil
         self._route = wrappedValue
-        self._priority = .normal
     }
     
     public var body: some View {

--- a/Sources/GSRouting/Utilities/AnyRoute.swift
+++ b/Sources/GSRouting/Utilities/AnyRoute.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-public enum RoutePriority: Int {
+public enum ActionPriority: Int {
     case low, normal, high, critical
 }
 
@@ -16,11 +16,11 @@ public enum RoutePriority: Int {
 public struct AnyViewRoute: ViewRoute {
         
     private let _route: any ViewRoute
-    private let _priority: RoutePriority
+    private let _priority: ActionPriority
     
     public var id: ID { _route.id }
     
-    public init(erasing wrappedValue: any ViewRoute, priority: RoutePriority) {
+    public init(erasing wrappedValue: any ViewRoute, priority: ActionPriority) {
         self._route = wrappedValue
         self._priority = priority
     }

--- a/Sources/GSRouting/Utilities/NavigationSteps.swift
+++ b/Sources/GSRouting/Utilities/NavigationSteps.swift
@@ -5,6 +5,16 @@
 //  Created by Ryan Cole on 2/12/2024.
 //
 
+/// Represents a step in the navigation hierarchy.
+///
+/// `NavigationStep` is an enum that defines the different types of navigation actions that can occur within the app.
+/// Each case includes an associated `id` string that identifies the destination of the navigation action.
+///
+/// - Cases:
+///   - `tab`: Represents switching to a tab, identified by a unique `id`.
+///   - `push`: Represents a push navigation to a new screen, identified by a unique `id`.
+///   - `sheet`: Represents presenting a modal sheet, identified by a unique `id`.
+///   - `fullScreen`: Represents presenting a full-screen modal, identified by a unique `id`.
 public enum NavigationStep: Equatable {
     case tab(id: String)
     case push(id: String)

--- a/Sources/GSRouting/Utilities/NavigationSteps.swift
+++ b/Sources/GSRouting/Utilities/NavigationSteps.swift
@@ -1,0 +1,13 @@
+//
+//  NavigationSteps.swift
+//  GSRouting
+//
+//  Created by Ryan Cole on 2/12/2024.
+//
+
+public enum NavigationStep: Equatable {
+    case tab(id: String)
+    case push(id: String)
+    case sheet(id: String)
+    case fullScreen(id: String)
+}

--- a/Sources/GSRouting/Utilities/QueueManager.swift
+++ b/Sources/GSRouting/Utilities/QueueManager.swift
@@ -1,0 +1,36 @@
+//
+//  QueueManager.swift
+//  GSRouting
+//
+//  Created by Ryan Cole on 4/12/2024.
+//
+
+import Foundation
+
+final class QueueManager: ObservableObject {
+    
+    @Published
+    private(set) var queue: [AnyViewRoute] = []
+    
+    private let delay: TimeInterval = 0.16
+    private let processingQueue = DispatchQueue(label: "com.gsrouting.queue")
+    
+    func enqueue(route: AnyViewRoute) {
+        processingQueue.async { [weak self] in
+            DispatchQueue.main.async {
+                self?.queue.append(route)
+                self?.queue.sort { $0.priority?.rawValue ?? .zero > $1.priority?.rawValue ?? .zero }
+            }
+        }
+    }
+    
+    func dequeue(completion: @escaping (AnyViewRoute) -> Void) {
+        processingQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
+            DispatchQueue.main.async {
+                if self?.queue.isEmpty == false, let next = self?.queue.removeFirst() {
+                    completion(next)
+                }
+            }
+        }
+    }
+}

--- a/Sources/GSRouting/ViewModifiers/EnvironmentValues.swift
+++ b/Sources/GSRouting/ViewModifiers/EnvironmentValues.swift
@@ -1,0 +1,12 @@
+//
+//  EnvironmentValues.swift
+//  GSRouting
+//
+//  Created by Ryan Cole on 2/12/2024.
+//
+
+import SwiftUI
+
+public extension EnvironmentValues {
+    @Entry var navigationPath = [NavigationStep]()
+}

--- a/Sources/GSRouting/ViewModifiers/EnvironmentValues.swift
+++ b/Sources/GSRouting/ViewModifiers/EnvironmentValues.swift
@@ -8,5 +8,9 @@
 import SwiftUI
 
 public extension EnvironmentValues {
+    /// This property stores an array of `NavigationStep` objects, representing the steps in the current navigation path.
+    /// It can be used to observe and react to  the navigation state in a SwiftUI environment.
+    ///
+    /// - Note: The default value is an empty array.
     @Entry var navigationPath = [NavigationStep]()
 }

--- a/Sources/GSRouting/ViewModifiers/Routable.swift
+++ b/Sources/GSRouting/ViewModifiers/Routable.swift
@@ -7,6 +7,11 @@
 
 import SwiftUI
 
+#warning("Deeplink handling history handling")
+#warning("Introduce navigation destination for hashable objects with lists")
+#warning("Documentation")
+#warning("Sheet and cover queue")
+
 fileprivate extension EnvironmentValues {
     @Entry var dismissRoot: (() -> Void)?
 }

--- a/Sources/GSRouting/ViewModifiers/Routable.swift
+++ b/Sources/GSRouting/ViewModifiers/Routable.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 #warning("Deeplink handling history handling")
-#warning("Documentation")
 #warning("Sheet and cover queue")
 
 fileprivate extension EnvironmentValues {
@@ -116,6 +115,7 @@ private extension RoutableViewModifier {
     
     func presentPath(_ path: [AnyViewRoute]) {
         self.path = path
+        self.trackablePath = path.map { .push(id: $0.id) }
     }
 
     func presentSheetView(sheet: AnyViewRoute) {

--- a/Sources/GSRouting/ViewModifiers/Routable.swift
+++ b/Sources/GSRouting/ViewModifiers/Routable.swift
@@ -11,7 +11,7 @@ fileprivate extension EnvironmentValues {
     @Entry var dismissRoot: (() -> Void)?
 }
 
-private struct RoutableViewModifier: ViewModifier {
+struct RoutableViewModifier: ViewModifier {
     
     @EnvironmentObject
     private var tabRouter: AppTabRouter
@@ -173,11 +173,5 @@ private extension RoutableViewModifier {
     
     func navigationDestinationView(_ destination: AnyViewRoute) -> some View {
         destination.body
-    }
-}
-
-extension View {
-    public func routable() -> some View {
-        modifier(RoutableViewModifier())
     }
 }

--- a/Sources/GSRouting/ViewModifiers/Routable.swift
+++ b/Sources/GSRouting/ViewModifiers/Routable.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 #warning("Deeplink handling history handling")
-#warning("Introduce navigation destination for hashable objects with lists")
 #warning("Documentation")
 #warning("Sheet and cover queue")
 

--- a/Sources/GSRouting/Views/RoutableTabView.swift
+++ b/Sources/GSRouting/Views/RoutableTabView.swift
@@ -68,7 +68,7 @@ public struct RoutableTabView: View {
     }
     
     private func contentView(tab: AnyTabRoute) -> some View {
-        tab.makeContent(context: makeContext(tab: tab))
+        tab.makeContent(context: makeContext(tab: tab)).modifier(RoutableViewModifier())
     }
     
     private func makeContext(tab: AnyTabRoute) -> TabRoute.Context {


### PR DESCRIPTION
 - Logging capabilities
 - New router functions for closing sheets and fullScreenCovers
 - New multi path navigation options for deep linking
 - You can now go to root through multiple sheets and covers
 - You can pop backwards to close a sheet or cover
 - No longer need to use the `routable` for navigating within sheets and covers
 - There is now a history of the steps taken in the path that is available in a environment value